### PR TITLE
Added check to see if a route has already been registered

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -14,9 +14,11 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
-        app($this::class)->setUpdateRoute(function ($handle) {
-            return Route::post('/livewire/update', $handle)->middleware('web');
-        });
+        if (!$this-updateRoute) {
+            app($this::class)->setUpdateRoute(function ($handle) {
+                return Route::post('/livewire/update', $handle)->middleware('web');
+            });
+        }
 
         $this->skipRequestPayloadTamperingMiddleware();
     }


### PR DESCRIPTION
A simple if around the core setUpdateRoute to check if one has already been defined.

This allows a user to call `Livewire::setUpdateRoute()` within the RouteServiceProvider register method without causing any problems.

I've also raised this as discussion #7962

Thanks!
